### PR TITLE
Modification d'une expression

### DIFF
--- a/french/pancake_lang.php
+++ b/french/pancake_lang.php
@@ -749,7 +749,7 @@ Les factures impayées sans date d\'échéance sont présentés en fonction de l
     'settings:wrong_license_key'					=> 'La clé de license que vous avez entré n\'est pas valide',
     'settings:noopenssl'							=> 'Votre serveur PHP n\'a pas de configuration OpenSSL active ce qui veut dire que vous ne pouvez pas utiliser Gmail ou d\'autres applications Google pour envoyer des courriels',
     'settings:logoremoved'							=> 'Logo retiré avec succès!',
-    'settings:save'									=> 'Sauvegarder les configurations',
+    'settings:save'									=> 'Sauvegarder',
     'settings:logodimensions'						=> 'Le logo devrait être d\'au moins 240 pixels de large et 106 pixels de haut',
     'settings:logoformatsallowed'					=> 'Seulement les fichiers de type BMP, PNG, JPG (JPEG) et GIF sont autorisés',
     'settings:ftp_user'								=> 'Utilisateur FTP',


### PR DESCRIPTION
Modification de l'expression 'settings:save' => 'Sauvegarder les modifications' pour 'Sauvegarder' car ça créait un erreur d'affichage avec les règles actuelles du CSS
