### PR TITLE
Mise à jour d'une expression

### DIFF
--- a/french/pancake_lang.php
+++ b/french/pancake_lang.php
@@ -1129,7 +1129,7 @@ Les factures impayées sans date d\'échéance sont présentés en fonction de l
     # Fin v4.1.28
     
     # Début des changements de la v4.1.29
-    "global:updates_available" => "Mise à jour disponible",
+    "global:update_available" => "Mise à jour disponible",
     #Fin v4.1.29
     
     # Début des changements de la v4.1.31


### PR DESCRIPTION
Correction de l'expression "global:update_available" qui était mal ortographié et qui faisait afficher une string au lieu de la traduction.
